### PR TITLE
Changes to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ WriteMakefile(
     NAME                => 'HTML::Element::Replacer',
     AUTHOR              => 'Terrence Brannon <tbone@cpan.org>',
     VERSION_FROM        => 'lib/HTML/Element/Replacer.pm',
-    ABSTRACT_FROM       => 'lib/HTML/Element/Replacer.pm',
+    ABSTRACT_FROM       => 'lib/HTML/Element/Replacer.pod',
     ($ExtUtils::MakeMaker::VERSION >= 6.3002
       ? ('LICENSE'=> 'perl')
       : ()),
@@ -17,6 +17,9 @@ WriteMakefile(
                   'HTML::Element::Library' => 4.2,
 		  'Moose' => 0.72,
     },
+    ($ExtUtils::MakeMaker::VERSION >= 6.48
+      ? ('MIN_PERL_VERSION' => '5.6.0')
+      : ()),
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'HTML-Element-Replacer-*' },
 );

--- a/lib/HTML/Element/Replacer.pod
+++ b/lib/HTML/Element/Replacer.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-  HTML::Element::Replacer - Simplify the HTML::Element clone() - push_content() ritual
+HTML::Element::Replacer - Simplify the HTML::Element clone() - push_content() ritual
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Here are some changes to Makefile.PL made as part of the [CPAN PR Challenge](http://cpan-prc.org).

1. The minimum version of perl is now specified as 5.6.0 as determined by perlver.
2. The ABSTRACT_FROM has changed to the pod file and that file has been amended to match against EUMM's abstract regex by removing the leading whitespace.